### PR TITLE
Fixed 2 tiny bugs

### DIFF
--- a/src/Plugins/libnotify.c
+++ b/src/Plugins/libnotify.c
@@ -182,7 +182,7 @@ static void libnotify_song_changed(MpdObj *mi)
 		}
 		g_log(LOG_DOMAIN, G_LOG_LEVEL_DEBUG, "libnotify version: %i %i %i\n", versions[0], versions[1], versions[2]);
 		if((versions[0] > 0) || (versions[0] == 0 && versions[1] >= 4))
-			mpd_song_markup(buffer, 1024, C_("Summary markup","%title%|%name%|%shortfile%"), song);
+			mpd_song_markup_escaped(buffer, 1024, C_("Summary markup","%title%|%name%|%shortfile%"), song);
 		else
 			mpd_song_markup_escaped(buffer, 1024, "%title%|%name%|%shortfile%", song);
 		summary = g_strdup(buffer);

--- a/src/tray-icon2.c
+++ b/src/tray-icon2.c
@@ -312,12 +312,9 @@ static void tray_icon2_init(void)
             g_signal_connect(G_OBJECT(tray_icon2_gsi), "popup-menu", G_CALLBACK(tray_icon2_populate_menu), NULL);
             g_signal_connect(G_OBJECT(tray_icon2_gsi), "activate", G_CALLBACK(tray_icon2_activate), NULL);
             g_signal_connect(G_OBJECT(tray_icon2_gsi), "notify::embedded", G_CALLBACK(tray_icon2_embedded_changed), NULL);
-            if (GTK_CHECK_VERSION(2, 15, 0))
-            {
-                g_signal_connect(G_OBJECT(tray_icon2_gsi), "button-press-event", G_CALLBACK(tray_icon2_button_press_event), NULL);
-                g_signal_connect(G_OBJECT(tray_icon2_gsi), "scroll-event", G_CALLBACK(tray_icon2_button_scroll_event), NULL);
-                /*g_signal_connect(G_OBJECT(tray_icon2_gsi), "query-tooltip", G_CALLBACK(tray_icon2_tooltip_query), NULL);*/
-            }
+            g_signal_connect(G_OBJECT(tray_icon2_gsi), "button-press-event", G_CALLBACK(tray_icon2_button_press_event), NULL);
+            g_signal_connect(G_OBJECT(tray_icon2_gsi), "scroll-event", G_CALLBACK(tray_icon2_button_scroll_event), NULL);
+            /*g_signal_connect(G_OBJECT(tray_icon2_gsi), "query-tooltip", G_CALLBACK(tray_icon2_tooltip_query), NULL);*/
         #ifdef HAVE_APP_INDICATOR
         }
         #endif // HAVE_APP_INDICATOR

--- a/src/tray-icon2.c
+++ b/src/tray-icon2.c
@@ -312,7 +312,7 @@ static void tray_icon2_init(void)
             g_signal_connect(G_OBJECT(tray_icon2_gsi), "popup-menu", G_CALLBACK(tray_icon2_populate_menu), NULL);
             g_signal_connect(G_OBJECT(tray_icon2_gsi), "activate", G_CALLBACK(tray_icon2_activate), NULL);
             g_signal_connect(G_OBJECT(tray_icon2_gsi), "notify::embedded", G_CALLBACK(tray_icon2_embedded_changed), NULL);
-            if (gtk_check_version(2, 15, 0) == NULL)
+            if (GTK_CHECK_VERSION(2, 15, 0))
             {
                 g_signal_connect(G_OBJECT(tray_icon2_gsi), "button-press-event", G_CALLBACK(tray_icon2_button_press_event), NULL);
                 g_signal_connect(G_OBJECT(tray_icon2_gsi), "scroll-event", G_CALLBACK(tray_icon2_button_scroll_event), NULL);


### PR DESCRIPTION
Missing markup escaping and gtk_check_version which does not check major version according to gtk documentation (disabled trayicon events).
