### PR TITLE
autotools: need libmpd 0.19.0, not 11.8.90

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,7 +220,7 @@ AC_SUBST(gmodule_LIBS)
 AC_SUBST(gmodule_CFLAGS)
 
 # libmpd
-PKG_CHECK_MODULES([libmpd], libmpd >= 11.8.90)
+PKG_CHECK_MODULES([libmpd], libmpd >= 0.19.0)
 AC_SUBST(libmpd_LIBS)
 AC_SUBST(libmpd_CFLAGS)
 


### PR DESCRIPTION
There has never been a libmpd release with major version !=0, according to at least http://gmpc.wikia.com/wiki/Libmpd. Debian unstable currently ships 0.20.0, while the most recent release at https://www.musicpd.org/ is 0.20.10. I chose the version released closest to the last gmpc release.

I'm seeing a problem compiling against 0.20.0 after applying this; I'll send fixes if this is accepted.