### PR TITLE
Fix wrong markup of desktop file in ca.po

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -24,7 +24,7 @@ msgstr ""
 #: ../src/browsers/gmpc-nowplaying2.c:4585
 #: ../src/browsers/gmpc-nowplaying2.c:4592
 msgid "Gnome Music Player Client"
-msgstr "Client de reproducció\nde música del GNOME"
+msgstr "Client de reproducció\\nde música del GNOME"
 
 #: ../data/gmpc.desktop.in.h:2
 msgid "A gnome frontend for the mpd daemon"


### PR DESCRIPTION
The markup does support newlines but only with proper escaping. This should clear the bug and show the entry again in the application menu.

This resolves https://github.com/DaveDavenport/gmpc/issues/4. Not strictly necessary, as it will be resolved with new translations, but that's probably the easiest and fastest way.
  